### PR TITLE
修复children.length改变后x不变问题

### DIFF
--- a/demo/page/demo.js
+++ b/demo/page/demo.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { InnerLayer, Popup, Select } from '../../src'
+import { InnerLayer, Popup, Select, Slider } from '../../src'
 
 class S extends React.Component {
   render () {
@@ -40,7 +40,18 @@ class P extends React.Component {
 }
 
 class DemoWrap extends React.Component {
+  state = {
+    arr: [1, 2, 3, 4, 5]
+  }
+
+  handleClick = () => {
+    this.setState({
+      arr: [1, 2, 3]
+    })
+  }
+
   render () {
+    const { arr } = this.state
     return (
       <div>
         <button onClick={() => {
@@ -49,6 +60,14 @@ class DemoWrap extends React.Component {
           })
         }}>innerLayer
         </button>
+        <div style={{ width: '500px', border: '1px solid #ddd' }}>
+          <Slider>
+            { arr.map(v => (
+              <div><h1>{v}</h1></div>
+            )) }
+          </Slider>
+        </div>
+        <button onClick={this.handleClick}>change slider length</button>
       </div>
     )
   }

--- a/src/component/slider/index.js
+++ b/src/component/slider/index.js
@@ -30,10 +30,14 @@ class Slider extends React.Component {
     this.refSlider = null
   }
 
-  componentWillReceiveProps (nextProps) {
-    this.setState({
-      count: _.isArray(nextProps.children) ? nextProps.children.length : 1
-    })
+  static getDerivedStateFromProps (props, state) {
+    const count = _.isArray(props.children) ? props.children.length : 1
+    if (state.count !== count) {
+      return {
+        count,
+        x: 0
+      }
+    }
   }
 
   doAutoSlider () {


### PR DESCRIPTION
### 问题场景
轮播图有5页，当前滑动到第4页，如果此时轮播图页数变成2页，就会出现白屏，原因是页数改变后，对应的滑动距离x并没有变
### 解决
轮播图页数改变后，重置x => 0
