### PR TITLE
ios10上 felx 支持不好的问题

### DIFF
--- a/src/component/letter_index/letter_index_multiple.js
+++ b/src/component/letter_index/letter_index_multiple.js
@@ -58,7 +58,7 @@ class LetterIndexMultiple extends React.Component {
           ...style
         }}
       >
-        <Flex column flex className='relative'>
+        <Flex column flex className='relative' style={{ height: '100%' }}>
           <List
             ref={this.refList}
             className='overflow-y relative'


### PR DESCRIPTION
通过 flex 属性撑满的元素，其子元素无法通过百分比来定高，增加一个 height: 100%，使子元素能定高